### PR TITLE
Update layout.toml

### DIFF
--- a/defaults/layouts/layout.toml
+++ b/defaults/layouts/layout.toml
@@ -238,7 +238,6 @@ tab_active_color = "-"
 tab_inactive_color = "-"
 tab_unread_color = "-"
 tab_unread_prefix = "* "
-text_color = "#ffffff"
 compass_active_color = "#00ff00"
 compass_inactive_color = "#333333"
 min_rows = 1


### PR DESCRIPTION
Duplicate text_color causing crash in default layout.toml file that is created upon fresh start.


Error: Failed to parse layout: "C:\\...\\.vellum-fe\\layouts\\layout.toml"

Caused by:
TOML parse error at line 241, column 1
       |
241 | text_color = "#ffffff"
       | ^
duplicate key 'text_color' in table 'windows'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove duplicate `text_color` key in `layout.toml` to fix TOML parse error.
> 
>   - **Fix**:
>     - Remove duplicate `text_color` key in `layout.toml` to prevent TOML parse error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nisugi%2FVellumFE&utm_source=github&utm_medium=referral)<sup> for eeb370c927f0d527ee3cdbf40b75d5caa2ee125f. You can [customize](https://app.ellipsis.dev/Nisugi/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->