### PR TITLE
Update sidebar.toml

### DIFF
--- a/defaults/layouts/sidebar.toml
+++ b/defaults/layouts/sidebar.toml
@@ -169,7 +169,6 @@ tab_active_color = "-"
 tab_inactive_color = "-"
 tab_unread_color = "-"
 tab_unread_prefix = "* "
-text_color = "#ffffff"
 compass_active_color = "#00ff00"
 compass_inactive_color = "#333333"
 min_rows = 1


### PR DESCRIPTION
Duplicate text_color with line causing parse errors, preventing load
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate `text_color` entry in `sidebar.toml` to fix parse errors.
> 
>   - **Fixes**:
>     - Removes duplicate `text_color` entry in `sidebar.toml` to fix parse errors preventing file load.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nisugi%2FVellumFE&utm_source=github&utm_medium=referral)<sup> for 18b990c0c3f5a35ec821e24db07b597fe5ef78bf. You can [customize](https://app.ellipsis.dev/Nisugi/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->